### PR TITLE
Replace lwip with jimp and package upgrades

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,70 +1,79 @@
-'use strict';
+"use strict";
 var fs = require("fs"),
-    lwip = require('lwip'),
-    exifParser = require('exif-parser'),
-    fs = require('fs-extra'),
-    Promise = require('bluebird');
-
+  jimp = require("jimp"),
+  exifParser = require("exif-parser"),
+  fs = require("fs-extra"),
+  Promise = require("bluebird");
 
 exports.exifFromFile = function(path) {
-    return new Promise(function(resolve, reject) {
-        fs.open(path, 'r', function (err, fd) {
-            if (err) return reject(err);
+  return new Promise(function(resolve, reject) {
+    fs.open(path, "r", function(err, fd) {
+      if (err) return reject(err);
 
-            // Read first 64K of image file (EXIF data located here)
-            var headSize = 65536;
-            var buffer = new Buffer(headSize);
-            fs.read(fd, buffer, 0, buffer.length, null, function (err, bytesRead, buffer) {
-                fs.close(fd);
-                if (err) return reject(err);
-
-                try {
-                    var parser = exifParser.create(buffer);
-                    var result = parser.parse();
-                    resolve(result);
-                } catch(exifError) {
-                    reject(exifError);
-                }
-            });
-        });
+      // Read first 64K of image file (EXIF data located here)
+      var headSize = 65536;
+      var buffer = new Buffer(headSize);
+      fs.read(fd, buffer, 0, buffer.length, null, function(
+        err,
+        bytesRead,
+        buffer
+      ) {
+        fs.close(fd);
+        if (err) return reject(err);
+        try {
+          var parser = exifParser.create(buffer);
+          var result = parser.parse();
+          resolve(result);
+        } catch (exifError) {
+          reject(exifError);
+        }
+      });
     });
-}
-
+  });
+};
 
 exports.autoRotateFile = function(source, destination) {
-    return this.exifFromFile(source)
-    .then(function(exif) {
-        return new Promise(function(resolve, reject) {
-            lwip.open(source, function(err, image) {
-                if( err ) return reject(err);
+  return this.exifFromFile(source).then(function(exif) {
+    return new Promise(function(resolve, reject) {
+      jimp.read(source, function(err, image) {
+        if (err) return reject(err);
 
-                var rotatedImage = rotate(exif.tags.Orientation, image.batch());
-                if( rotatedImage ) {
-                    rotatedImage.writeFile(destination, function(err) {
-                        if( err ) return reject(err);
-                        resolve(rotatedImage);
-                    });
-                } else if( source !== destination ) {
-                    fs.copy(source, destination, function(err) {
-                        if( err ) return reject(err);
-                        resolve();
-                    });
-                } else {resolve(); }
-            });
-        });
+        var rotatedImage = rotate(exif.tags.Orientation, image);
+        if (rotatedImage) {
+          rotatedImage.write(destination, function(err) {
+            if (err) return reject(err);
+            resolve(rotatedImage);
+          });
+        } else if (source !== destination) {
+          fs.copy(source, destination, function(err) {
+            if (err) return reject(err);
+            resolve();
+          });
+        } else {
+          resolve();
+        }
+      });
     });
-}
-
+  });
+};
 
 function rotate(currentOrientation, image) {
-	switch( currentOrientation ) {
-	    case 1: return; // top-left  - no transform
-	    case 2: return image.flip('x'); //	top-right - flip horizontal
-	    case 3: return image.rotate(180); // bottom-right - rotate 180
-	    case 4: return image.flip('y'); // bottom-left - flip vertically
-	    case 5: return image.rotate(90).flip('x'); // left-top - rotate 90 and flip horizontal
-	    case 6: return image.rotate(90); //	right-top - rotate 90
-	    case 7: return image.rotate(270).flip('x'); // right-bottom - rotate 270 and flip horizontal
-	    case 8: return image.rotate(270); // left-bottom - rotate 270
-    };
+  switch (currentOrientation) {
+    case 1:
+      return; // top-left  - no transform
+    case 2:
+      return image.flip("horz"); //	top-right - flip horizontal
+    case 3:
+      return image.rotate(180); // bottom-right - rotate 180
+    case 4:
+      return image.flip("vert"); // bottom-left - flip vertically
+    case 5:
+      return image.rotate(90).flip("horz"); // left-top - rotate 90 and flip horizontal
+    case 6:
+      return image.rotate(90); //	right-top - rotate 90
+    case 7:
+      return image.rotate(270).flip("horz"); // right-bottom - rotate 270 and flip horizontal
+    case 8:
+      return image.rotate(270); // left-bottom - rotate 270
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,32 +1,18 @@
 {
-  "name": "auto-rotate",
-  "version": "1.0.7",
-  "description": "Auto rotate JPEG images based on their EXIF Orientation tag. Promise based API.",
+  "name": "rotatest",
+  "version": "1.0.0",
+  "description": "",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/vonheim/node-auto-rotate"
-  },
-  "keywords": [
-    "autorotate",
-    "rotate",
-    "exif",
-    "jpeg",
-    "promise"
-  ],
-  "author": "Arne Vonheim",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/vonheim/auto-rotate/issues"
-  },
-  "homepage": "https://github.com/vonheim/auto-rotate",
   "dependencies": {
-    "bluebird": "^2.9.34",
-    "exif-parser": "^0.1.9",
-    "fs-extra": "^0.24.0",
-    "lwip": "0.0.9"
-  }
+    "bluebird": "^3.5.1",
+    "exif-parser": "0.1.12",
+    "fs-extra": "^5.0.0",
+    "jimp": "0.2.28"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
 }


### PR DESCRIPTION
jimp is pure-js (avoids node-gyp) and works with node LTS carbon (8.9.*)
Fix exif-parser bug by updating version: sometimes the wrong Orientation value was returned